### PR TITLE
feat: implementasi API registrasi user baru

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,13 @@
     "": {
       "name": "belajar-vibe-coding",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "drizzle-orm": "^0.45.2",
         "elysia": "^1.4.28",
         "mysql2": "^3.20.0",
       },
       "devDependencies": {
+        "@types/bcryptjs": "^3.0.0",
         "@types/bun": "latest",
         "drizzle-kit": "^0.31.10",
       },
@@ -85,11 +87,15 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
+    "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
+
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 

--- a/drizzle/0000_fluffy_timeslip.sql
+++ b/drizzle/0000_fluffy_timeslip.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `users` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`name` varchar(255) NOT NULL,
+	`email` varchar(255) NOT NULL,
+	`password` varchar(255) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	`updated_at` timestamp NOT NULL DEFAULT (now()) ON UPDATE CURRENT_TIMESTAMP,
+	CONSTRAINT `users_id` PRIMARY KEY(`id`),
+	CONSTRAINT `users_email_unique` UNIQUE(`email`)
+);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,87 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "b7612d26-7950-4ee5-8ef4-57fb02a30425",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "onUpdate": true,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "mysql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1775363855389,
+      "tag": "0000_fluffy_timeslip",
+      "breakpoints": true
+    }
+  ]
+}

--- a/issue.md
+++ b/issue.md
@@ -1,41 +1,209 @@
-# Project Setup: Bun + ElysiaJS + Drizzle + MySQL
+# Issue: Implementasi API Registrasi User Baru
 
-## Overview
+## Deskripsi
 
-Buat REST API project baru menggunakan Bun sebagai runtime, ElysiaJS sebagai web framework, Drizzle sebagai ORM, dan MySQL sebagai database.
-
----
-
-## Tasks
-
-### 1. Inisialisasi Project
-- Buat project baru dengan `bun init`
-- Setup `package.json` dengan scripts: `dev`, `start`, `db:generate`, `db:migrate`
-
-### 2. Install Dependencies
-- `elysia` — web framework
-- `drizzle-orm` + `mysql2` — ORM dan MySQL driver
-- `drizzle-kit` (devDependency) — untuk migration dan schema generation
-
-### 3. Konfigurasi Database
-- Buat file koneksi database (contoh: `src/db/index.ts`)
-- Gunakan environment variable untuk DB credentials (`.env`)
-- Buat `drizzle.config.ts` untuk konfigurasi drizzle-kit
-
-### 4. Buat Schema
-- Buat minimal 1 contoh table/schema di `src/db/schema.ts`
-- Generate migration dengan `drizzle-kit generate`
-- Jalankan migration dengan `drizzle-kit migrate`
-
-### 5. Setup ElysiaJS App
-- Buat entry point di `src/index.ts`
-- Daftarkan minimal 1 route contoh (CRUD sederhana) yang terhubung ke database
-- Jalankan server dengan Bun
+Buatkan API endpoint untuk registrasi user baru dengan hashing password menggunakan bcrypt.
 
 ---
 
-## Acceptance Criteria
+## 1. Update Tabel Users
 
-- Server bisa dijalankan dengan `bun run dev`
-- Bisa konek ke MySQL
-- Minimal ada 1 endpoint yang baca/tulis data dari database
+Tabel `users` sudah ada di `src/db/schema.ts`, tetapi perlu ditambahkan kolom berikut:
+
+| Kolom      | Tipe             | Constraint                                      |
+| ---------- | ---------------- | ----------------------------------------------- |
+| id         | int              | autoincrement, primary key (sudah ada)          |
+| name       | varchar(255)     | not null (sudah ada)                            |
+| email      | varchar(255)     | not null, unique (sudah ada)                    |
+| password   | varchar(255)     | not null (BARU - berisi hash bcrypt)            |
+| created_at | timestamp        | default current_timestamp (sudah ada)           |
+| updated_at | timestamp        | default current_timestamp on update (BARU)      |
+
+## 2. API Endpoint
+
+**Endpoint:** `POST /api/users`
+
+**Request Body:**
+```json
+{
+  "name": "agung",
+  "email": "agung@mail.com",
+  "password": "rahasia"
+}
+```
+
+**Response Body (sukses):**
+```json
+{
+  "data": "OK"
+}
+```
+
+**Response Body (error - email duplikat):**
+```json
+{
+  "error": "email sudah terdaftar"
+}
+```
+
+## 3. Struktur Folder & File
+
+```
+src/
+├── db/
+│   ├── index.ts        (sudah ada - koneksi database)
+│   └── schema.ts       (sudah ada - perlu diupdate)
+├── route/
+│   └── users-route.ts  (BARU)
+├── service/
+│   └── users-service.ts (BARU)
+└── index.ts            (sudah ada - perlu diupdate)
+```
+
+- `src/route/` : berisi routing Elysia JS
+- `src/service/` : berisi logic bisnis aplikasi
+
+---
+
+## Tahapan Implementasi
+
+### Tahap 1: Install dependency bcrypt
+
+Jalankan perintah berikut untuk menginstall package bcrypt:
+
+```bash
+bun add bcryptjs
+bun add -d @types/bcryptjs
+```
+
+> Gunakan `bcryptjs` (versi pure JS) agar kompatibel dengan Bun runtime.
+
+---
+
+### Tahap 2: Update schema `src/db/schema.ts`
+
+Tambahkan kolom `password` dan `updatedAt` pada tabel users.
+
+**File:** `src/db/schema.ts`
+
+```ts
+import { mysqlTable, int, varchar, timestamp } from "drizzle-orm/mysql-core";
+
+export const users = mysqlTable("users", {
+  id: int("id").autoincrement().primaryKey(),
+  name: varchar("name", { length: 255 }).notNull(),
+  email: varchar("email", { length: 255 }).notNull().unique(),
+  password: varchar("password", { length: 255 }).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().onUpdateNow().notNull(),
+});
+```
+
+Setelah update schema, jalankan migrasi:
+
+```bash
+bunx drizzle-kit generate
+bunx drizzle-kit migrate
+```
+
+---
+
+### Tahap 3: Buat service `src/service/users-service.ts`
+
+File ini berisi logic bisnis untuk registrasi user.
+
+**File:** `src/service/users-service.ts`
+
+Yang harus dilakukan:
+1. Import `db` dari `src/db/index.ts`
+2. Import `users` dari `src/db/schema.ts`
+3. Import `bcryptjs` untuk hashing password
+4. Import `eq` dari `drizzle-orm` untuk query condition
+5. Buat fungsi `createUser(name: string, email: string, password: string)` yang:
+   - Cek apakah email sudah terdaftar di database menggunakan `db.select().from(users).where(eq(users.email, email))`
+   - Jika email sudah ada, throw error dengan pesan `"email sudah terdaftar"`
+   - Jika belum ada, hash password menggunakan `bcryptjs.hash(password, 10)`
+   - Insert user baru ke database menggunakan `db.insert(users).values({ name, email, password: hashedPassword })`
+   - Return `"OK"`
+6. Export fungsi `createUser`
+
+---
+
+### Tahap 4: Buat route `src/route/users-route.ts`
+
+File ini berisi routing untuk endpoint user.
+
+**File:** `src/route/users-route.ts`
+
+Yang harus dilakukan:
+1. Import `Elysia` dari `elysia`
+2. Import fungsi `createUser` dari `src/service/users-service.ts`
+3. Buat instance `Elysia` dengan prefix `/api/users`
+4. Tambahkan route `POST /` yang:
+   - Ambil `name`, `email`, `password` dari request body
+   - Panggil `createUser(name, email, password)`
+   - Jika sukses, return `{ data: "OK" }`
+   - Jika error, return `{ error: error.message }` dengan status code 400
+5. Export route tersebut
+
+---
+
+### Tahap 5: Daftarkan route di `src/index.ts`
+
+Update file entry point untuk menggunakan route yang sudah dibuat.
+
+**File:** `src/index.ts`
+
+Yang harus dilakukan:
+1. Import `usersRoute` dari `src/route/users-route.ts`
+2. Gunakan `.use(usersRoute)` pada instance Elysia
+
+Contoh hasil akhir:
+
+```ts
+import { Elysia } from "elysia";
+import { usersRoute } from "./route/users-route";
+
+const app = new Elysia()
+  .use(usersRoute)
+  .listen(3000);
+
+console.log(`Server running at http://localhost:${app.server?.port}`);
+```
+
+---
+
+### Tahap 6: Testing
+
+Setelah semua tahap selesai, jalankan server dan test endpoint:
+
+```bash
+bun run dev
+```
+
+**Test dengan curl:**
+
+```bash
+# Test registrasi user baru (harus return {"data":"OK"})
+curl -X POST http://localhost:3000/api/users \
+  -H "Content-Type: application/json" \
+  -d '{"name":"agung","email":"agung@mail.com","password":"rahasia"}'
+
+# Test email duplikat (harus return {"error":"email sudah terdaftar"})
+curl -X POST http://localhost:3000/api/users \
+  -H "Content-Type: application/json" \
+  -d '{"name":"agung2","email":"agung@mail.com","password":"rahasia"}'
+```
+
+---
+
+## Checklist
+
+- [ ] Install dependency `bcryptjs` dan `@types/bcryptjs`
+- [ ] Update schema di `src/db/schema.ts` (tambah kolom `password` dan `updatedAt`)
+- [ ] Jalankan migrasi database (`drizzle-kit generate` dan `drizzle-kit migrate`)
+- [ ] Buat file `src/service/users-service.ts`
+- [ ] Buat file `src/route/users-route.ts`
+- [ ] Update `src/index.ts` untuk register route
+- [ ] Test endpoint `POST /api/users` - registrasi sukses
+- [ ] Test endpoint `POST /api/users` - email duplikat

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "db:migrate": "drizzle-kit migrate"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^3.0.0",
     "@types/bun": "latest",
     "drizzle-kit": "^0.31.10"
   },
@@ -17,6 +18,7 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "drizzle-orm": "^0.45.2",
     "elysia": "^1.4.28",
     "mysql2": "^3.20.0"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,5 +4,7 @@ export const users = mysqlTable("users", {
   id: int("id").autoincrement().primaryKey(),
   name: varchar("name", { length: 255 }).notNull(),
   email: varchar("email", { length: 255 }).notNull().unique(),
+  password: varchar("password", { length: 255 }).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().onUpdateNow().notNull(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { Elysia } from "elysia";
+import { usersRoute } from "./route/users-route";
 
 const app = new Elysia()
+  .use(usersRoute)
   .listen(3000);
 
 console.log(`Server running at http://localhost:${app.server?.port}`);

--- a/src/route/users-route.ts
+++ b/src/route/users-route.ts
@@ -1,0 +1,20 @@
+import { Elysia } from "elysia";
+import { createUser } from "../service/users-service";
+
+export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
+  "/",
+  async ({ body, set }) => {
+    try {
+      const { name, email, password } = body as {
+        name: string;
+        email: string;
+        password: string;
+      };
+      await createUser(name, email, password);
+      return { data: "OK" };
+    } catch (error) {
+      set.status = 400;
+      return { error: (error as Error).message };
+    }
+  }
+);

--- a/src/service/users-service.ts
+++ b/src/service/users-service.ts
@@ -1,0 +1,29 @@
+import { eq } from "drizzle-orm";
+import bcrypt from "bcryptjs";
+import { db } from "../db";
+import { users } from "../db/schema";
+
+export async function createUser(
+  name: string,
+  email: string,
+  password: string
+) {
+  const existing = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, email));
+
+  if (existing.length > 0) {
+    throw new Error("email sudah terdaftar");
+  }
+
+  const hashedPassword = await bcrypt.hash(password, 10);
+
+  await db.insert(users).values({
+    name,
+    email,
+    password: hashedPassword,
+  });
+
+  return "OK";
+}


### PR DESCRIPTION
## Summary

- Tambah kolom `password` dan `updatedAt` pada tabel `users`
- Buat migration drizzle untuk perubahan schema
- Buat `src/service/users-service.ts` dengan logika `createUser` + bcrypt hashing + validasi email duplikat
- Buat `src/route/users-route.ts` dengan endpoint `POST /api/users`
- Update `src/index.ts` untuk register route baru

Closes #4

## Test plan

- [x] `POST /api/users` dengan data valid → response `{"data":"OK"}`
- [x] `POST /api/users` dengan email yang sudah terdaftar → response `{"error":"email sudah terdaftar"}` (status 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)