### PR TITLE
feat: implementasi API POST /api/users/logout

### DIFF
--- a/issue.md
+++ b/issue.md
@@ -1,94 +1,25 @@
-# Issue: Implementasi API Registrasi User Baru
+# Issue: Implementasi API Logout User
 
 ## Deskripsi
 
-Buatkan API endpoint untuk registrasi user baru dengan hashing password menggunakan bcrypt.
+Buatkan API endpoint untuk logout user. Endpoint ini akan menghapus session (token) dari tabel `sessions` sehingga token tersebut tidak bisa digunakan lagi.
 
 ---
 
-## 1. Update Tabel Users
+## Konteks Project
 
-Tabel `users` sudah ada di `src/db/schema.ts`, tetapi perlu ditambahkan kolom berikut:
+Project ini menggunakan stack:
+- **Runtime:** Bun
+- **Framework:** ElysiaJS
+- **ORM:** Drizzle ORM
+- **Database:** MySQL
 
-| Kolom      | Tipe             | Constraint                                      |
-| ---------- | ---------------- | ----------------------------------------------- |
-| id         | int              | autoincrement, primary key (sudah ada)          |
-| name       | varchar(255)     | not null (sudah ada)                            |
-| email      | varchar(255)     | not null, unique (sudah ada)                    |
-| password   | varchar(255)     | not null (BARU - berisi hash bcrypt)            |
-| created_at | timestamp        | default current_timestamp (sudah ada)           |
-| updated_at | timestamp        | default current_timestamp on update (BARU)      |
-
-## 2. API Endpoint
-
-**Endpoint:** `POST /api/users`
-
-**Request Body:**
-```json
-{
-  "name": "agung",
-  "email": "agung@mail.com",
-  "password": "rahasia"
-}
-```
-
-**Response Body (sukses):**
-```json
-{
-  "data": "OK"
-}
-```
-
-**Response Body (error - email duplikat):**
-```json
-{
-  "error": "email sudah terdaftar"
-}
-```
-
-## 3. Struktur Folder & File
-
-```
-src/
-├── db/
-│   ├── index.ts        (sudah ada - koneksi database)
-│   └── schema.ts       (sudah ada - perlu diupdate)
-├── route/
-│   └── users-route.ts  (BARU)
-├── service/
-│   └── users-service.ts (BARU)
-└── index.ts            (sudah ada - perlu diupdate)
-```
-
-- `src/route/` : berisi routing Elysia JS
-- `src/service/` : berisi logic bisnis aplikasi
-
----
-
-## Tahapan Implementasi
-
-### Tahap 1: Install dependency bcrypt
-
-Jalankan perintah berikut untuk menginstall package bcrypt:
-
-```bash
-bun add bcryptjs
-bun add -d @types/bcryptjs
-```
-
-> Gunakan `bcryptjs` (versi pure JS) agar kompatibel dengan Bun runtime.
-
----
-
-### Tahap 2: Update schema `src/db/schema.ts`
-
-Tambahkan kolom `password` dan `updatedAt` pada tabel users.
+### Schema yang Sudah Ada
 
 **File:** `src/db/schema.ts`
 
 ```ts
-import { mysqlTable, int, varchar, timestamp } from "drizzle-orm/mysql-core";
-
+// Tabel users
 export const users = mysqlTable("users", {
   id: int("id").autoincrement().primaryKey(),
   name: varchar("name", { length: 255 }).notNull(),
@@ -97,113 +28,268 @@ export const users = mysqlTable("users", {
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().onUpdateNow().notNull(),
 });
+
+// Tabel sessions (menyimpan token login)
+export const sessions = mysqlTable("sessions", {
+  id: int("id").autoincrement().primaryKey(),
+  token: varchar("token", { length: 255 }).notNull(),
+  userId: int("user_id").notNull().references(() => users.id),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
 ```
 
-Setelah update schema, jalankan migrasi:
+### Endpoint yang Sudah Ada
 
-```bash
-bunx drizzle-kit generate
-bunx drizzle-kit migrate
+| Method | Endpoint              | Fungsi                          |
+| ------ | --------------------- | ------------------------------- |
+| POST   | /api/users            | Registrasi user baru            |
+| POST   | /api/users/login      | Login user (return token)       |
+| POST   | /api/users/current    | Get data user yang sedang login |
+
+### Alur Login yang Sudah Ada
+
+1. User login via `POST /api/users/login` dengan email & password
+2. Server memvalidasi credential
+3. Server membuat token (UUID) dan menyimpannya di tabel `sessions` dengan `user_id`
+4. Server mengembalikan token ke client
+
+**Saat logout, token ini akan dihapus dari tabel `sessions`.**
+
+---
+
+## API Endpoint yang Akan Dibuat
+
+**Endpoint:** `POST /api/users/logout`
+
+**Headers:**
+```
+Authorization: Bearer <token>
 ```
 
----
+> Token diambil dari response login (`POST /api/users/login`).
 
-### Tahap 3: Buat service `src/service/users-service.ts`
+**Response Body (Success - 200):**
+```json
+{
+  "data": "OK"
+}
+```
 
-File ini berisi logic bisnis untuk registrasi user.
+> Jika sukses logout, session dengan token tersebut akan **dihapus** dari tabel `sessions`.
 
-**File:** `src/service/users-service.ts`
+**Response Body (Error - 401):**
+```json
+{
+  "error": "Unauthorized"
+}
+```
 
-Yang harus dilakukan:
-1. Import `db` dari `src/db/index.ts`
-2. Import `users` dari `src/db/schema.ts`
-3. Import `bcryptjs` untuk hashing password
-4. Import `eq` dari `drizzle-orm` untuk query condition
-5. Buat fungsi `createUser(name: string, email: string, password: string)` yang:
-   - Cek apakah email sudah terdaftar di database menggunakan `db.select().from(users).where(eq(users.email, email))`
-   - Jika email sudah ada, throw error dengan pesan `"email sudah terdaftar"`
-   - Jika belum ada, hash password menggunakan `bcryptjs.hash(password, 10)`
-   - Insert user baru ke database menggunakan `db.insert(users).values({ name, email, password: hashedPassword })`
-   - Return `"OK"`
-6. Export fungsi `createUser`
-
----
-
-### Tahap 4: Buat route `src/route/users-route.ts`
-
-File ini berisi routing untuk endpoint user.
-
-**File:** `src/route/users-route.ts`
-
-Yang harus dilakukan:
-1. Import `Elysia` dari `elysia`
-2. Import fungsi `createUser` dari `src/service/users-service.ts`
-3. Buat instance `Elysia` dengan prefix `/api/users`
-4. Tambahkan route `POST /` yang:
-   - Ambil `name`, `email`, `password` dari request body
-   - Panggil `createUser(name, email, password)`
-   - Jika sukses, return `{ data: "OK" }`
-   - Jika error, return `{ error: error.message }` dengan status code 400
-5. Export route tersebut
+> Dikembalikan jika token tidak ada, format header salah, atau token tidak ditemukan di database.
 
 ---
 
-### Tahap 5: Daftarkan route di `src/index.ts`
+## Struktur Folder & File
 
-Update file entry point untuk menggunakan route yang sudah dibuat.
+```
+src/
+├── db/
+│   ├── index.ts          (sudah ada - koneksi database - TIDAK perlu diubah)
+│   └── schema.ts         (sudah ada - schema database - TIDAK perlu diubah)
+├── route/
+│   └── users-route.ts    (sudah ada - perlu ditambah endpoint baru)
+├── service/
+│   └── users-service.ts  (sudah ada - perlu ditambah fungsi baru)
+└── index.ts              (sudah ada - TIDAK perlu diubah)
+```
 
-**File:** `src/index.ts`
+- `src/route/` : berisi routing ElysiaJS
+- `src/service/` : berisi logic bisnis aplikasi
 
-Yang harus dilakukan:
-1. Import `usersRoute` dari `src/route/users-route.ts`
-2. Gunakan `.use(usersRoute)` pada instance Elysia
+---
 
-Contoh hasil akhir:
+## Tahapan Implementasi
+
+### Tahap 1: Tambah fungsi `logoutUser` di `src/service/users-service.ts`
+
+Buka file `src/service/users-service.ts`. Di file ini sudah ada fungsi `getCurrentUser`, `createUser`, dan `loginUser`.
+
+**Tambahkan fungsi baru `logoutUser(token: string)` dengan logika berikut:**
+
+1. Ambil nilai `token` dari parameter fungsi
+2. Cari session di tabel `sessions` yang memiliki token tersebut:
+   ```ts
+   const session = await db.select().from(sessions).where(eq(sessions.token, token));
+   ```
+3. Jika session **tidak ditemukan** (array kosong), throw error dengan pesan `"Unauthorized"`
+4. Jika session **ditemukan**, hapus session tersebut dari tabel `sessions`:
+   ```ts
+   await db.delete(sessions).where(eq(sessions.token, token));
+   ```
+5. Return string `"OK"`
+
+**Contoh fungsi lengkap:**
 
 ```ts
-import { Elysia } from "elysia";
-import { usersRoute } from "./route/users-route";
+export async function logoutUser(token: string) {
+  const session = await db.select().from(sessions).where(eq(sessions.token, token));
 
-const app = new Elysia()
-  .use(usersRoute)
-  .listen(3000);
+  if (session.length === 0) {
+    throw new Error("Unauthorized");
+  }
 
-console.log(`Server running at http://localhost:${app.server?.port}`);
+  await db.delete(sessions).where(eq(sessions.token, token));
+
+  return "OK";
+}
 ```
+
+**Penting:**
+- Import `sessions` dari `../db/schema` sudah ada di baris import yang ada, jadi **tidak perlu** menambah import baru
+- Gunakan `db.delete()` dari Drizzle ORM untuk menghapus row
+- Pastikan fungsi `logoutUser` di-**export** agar bisa digunakan di route
 
 ---
 
-### Tahap 6: Testing
+### Tahap 2: Tambah endpoint `POST /api/users/logout` di `src/route/users-route.ts`
 
-Setelah semua tahap selesai, jalankan server dan test endpoint:
+Buka file `src/route/users-route.ts`. Di file ini sudah ada route `POST /`, `POST /login`, dan `POST /current`.
+
+**Tambahkan route baru dengan cara chaining `.post("/logout", ...)` pada instance Elysia yang sudah ada.**
+
+1. Tambahkan import `logoutUser` di baris import yang sudah ada:
+   ```ts
+   import { createUser, loginUser, getCurrentUser, logoutUser } from "../service/users-service";
+   ```
+
+2. Tambahkan route baru setelah route `/current` yang sudah ada, dengan cara menambah `.post("/logout", ...)`:
+   ```ts
+   .post("/logout", async ({ request, set }) => {
+     try {
+       const authHeader = request.headers.get("authorization");
+       if (!authHeader || !authHeader.startsWith("Bearer ")) {
+         set.status = 401;
+         return { error: "Unauthorized" };
+       }
+       const token = authHeader.replace("Bearer ", "");
+       const result = await logoutUser(token);
+       return { data: result };
+     } catch (error) {
+       set.status = 401;
+       return { error: "Unauthorized" };
+     }
+   })
+   ```
+
+**Penting:**
+- Pola handler ini **sama persis** dengan route `/current` yang sudah ada, bedanya hanya memanggil `logoutUser` bukan `getCurrentUser`
+- Pastikan chaining `.post(...)` ditambahkan **sebelum** semicolon (`;`) penutup
+- Status code untuk semua error di endpoint ini adalah **401** (bukan 400)
+- Gunakan `request` dari context ElysiaJS untuk mengakses headers
+
+---
+
+### Tahap 3: Testing
+
+Jalankan server:
 
 ```bash
 bun run dev
 ```
 
-**Test dengan curl:**
+**Test 1 - Login dulu untuk mendapatkan token:**
 
 ```bash
-# Test registrasi user baru (harus return {"data":"OK"})
-curl -X POST http://localhost:3000/api/users \
+curl -X POST http://localhost:3000/api/users/login \
   -H "Content-Type: application/json" \
-  -d '{"name":"agung","email":"agung@mail.com","password":"rahasia"}'
+  -d '{"email":"agung@mail.com","password":"rahasia"}'
+```
 
-# Test email duplikat (harus return {"error":"email sudah terdaftar"})
-curl -X POST http://localhost:3000/api/users \
-  -H "Content-Type: application/json" \
-  -d '{"name":"agung2","email":"agung@mail.com","password":"rahasia"}'
+Catat token dari response, contoh: `"data": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"`
+
+**Test 2 - Logout dengan token valid (harus return "OK"):**
+
+```bash
+curl -X POST http://localhost:3000/api/users/logout \
+  -H "Authorization: Bearer xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+Expected response:
+```json
+{
+  "data": "OK"
+}
+```
+
+**Test 3 - Verifikasi token sudah tidak bisa dipakai lagi (harus return error 401):**
+
+```bash
+curl -X POST http://localhost:3000/api/users/current \
+  -H "Authorization: Bearer xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+Expected response (karena token sudah dihapus):
+```json
+{
+  "error": "Unauthorized"
+}
+```
+
+**Test 4 - Logout tanpa header Authorization (harus return error 401):**
+
+```bash
+curl -X POST http://localhost:3000/api/users/logout
+```
+
+Expected response:
+```json
+{
+  "error": "Unauthorized"
+}
+```
+
+**Test 5 - Logout dengan token yang salah/tidak ada (harus return error 401):**
+
+```bash
+curl -X POST http://localhost:3000/api/users/logout \
+  -H "Authorization: Bearer token-yang-salah"
+```
+
+Expected response:
+```json
+{
+  "error": "Unauthorized"
+}
+```
+
+**Test 6 - Logout dua kali dengan token yang sama (harus error di percobaan kedua):**
+
+```bash
+# Logout pertama - harus sukses
+curl -X POST http://localhost:3000/api/users/logout \
+  -H "Authorization: Bearer xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# Logout kedua dengan token yang sama - harus error 401
+curl -X POST http://localhost:3000/api/users/logout \
+  -H "Authorization: Bearer xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+```
+
+Expected response logout kedua:
+```json
+{
+  "error": "Unauthorized"
+}
 ```
 
 ---
 
 ## Checklist
 
-- [ ] Install dependency `bcryptjs` dan `@types/bcryptjs`
-- [ ] Update schema di `src/db/schema.ts` (tambah kolom `password` dan `updatedAt`)
-- [ ] Jalankan migrasi database (`drizzle-kit generate` dan `drizzle-kit migrate`)
-- [ ] Buat file `src/service/users-service.ts`
-- [ ] Buat file `src/route/users-route.ts`
-- [ ] Update `src/index.ts` untuk register route
-- [ ] Test endpoint `POST /api/users` - registrasi sukses
-- [ ] Test endpoint `POST /api/users` - email duplikat
+- [ ] Tambah fungsi `logoutUser(token)` di `src/service/users-service.ts`
+- [ ] Tambah import `logoutUser` di `src/route/users-route.ts`
+- [ ] Tambah route `POST /api/users/logout` di `src/route/users-route.ts`
+- [ ] Test endpoint - login dulu untuk dapat token
+- [ ] Test endpoint - logout dengan token valid (response `"OK"`)
+- [ ] Test endpoint - verifikasi token sudah tidak bisa dipakai setelah logout
+- [ ] Test endpoint - logout tanpa header Authorization (response 401)
+- [ ] Test endpoint - logout dengan token salah (response 401)
+- [ ] Test endpoint - logout dua kali dengan token sama (kedua harus 401)

--- a/src/route/users-route.ts
+++ b/src/route/users-route.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { createUser, loginUser, getCurrentUser } from "../service/users-service";
+import { createUser, loginUser, getCurrentUser, logoutUser } from "../service/users-service";
 
 export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
   "/",
@@ -41,6 +41,21 @@ export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
       const token = authHeader.replace("Bearer ", "");
       const user = await getCurrentUser(token);
       return { data: user };
+    } catch (error) {
+      set.status = 401;
+      return { error: "Unauthorized" };
+    }
+  })
+  .post("/logout", async ({ request, set }) => {
+    try {
+      const authHeader = request.headers.get("authorization");
+      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        set.status = 401;
+        return { error: "Unauthorized" };
+      }
+      const token = authHeader.replace("Bearer ", "");
+      const result = await logoutUser(token);
+      return { data: result };
     } catch (error) {
       set.status = 401;
       return { error: "Unauthorized" };

--- a/src/route/users-route.ts
+++ b/src/route/users-route.ts
@@ -1,6 +1,12 @@
 import { Elysia } from "elysia";
 import { createUser, loginUser, getCurrentUser, logoutUser } from "../service/users-service";
 
+function extractBearerToken(request: Request): string | null {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+  return authHeader.slice(7);
+}
+
 export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
   "/",
   async ({ body, set }) => {
@@ -33,12 +39,11 @@ export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
   })
   .post("/current", async ({ request, set }) => {
     try {
-      const authHeader = request.headers.get("authorization");
-      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      const token = extractBearerToken(request);
+      if (!token) {
         set.status = 401;
         return { error: "Unauthorized" };
       }
-      const token = authHeader.replace("Bearer ", "");
       const user = await getCurrentUser(token);
       return { data: user };
     } catch (error) {
@@ -48,12 +53,11 @@ export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
   })
   .post("/logout", async ({ request, set }) => {
     try {
-      const authHeader = request.headers.get("authorization");
-      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      const token = extractBearerToken(request);
+      if (!token) {
         set.status = 401;
         return { error: "Unauthorized" };
       }
-      const token = authHeader.replace("Bearer ", "");
       const result = await logoutUser(token);
       return { data: result };
     } catch (error) {

--- a/src/service/users-service.ts
+++ b/src/service/users-service.ts
@@ -51,13 +51,11 @@ export async function createUser(
 }
 
 export async function logoutUser(token: string) {
-  const session = await db.select().from(sessions).where(eq(sessions.token, token));
+  const result = await db.delete(sessions).where(eq(sessions.token, token));
 
-  if (session.length === 0) {
+  if (result[0].affectedRows === 0) {
     throw new Error("Unauthorized");
   }
-
-  await db.delete(sessions).where(eq(sessions.token, token));
 
   return "OK";
 }

--- a/src/service/users-service.ts
+++ b/src/service/users-service.ts
@@ -50,6 +50,18 @@ export async function createUser(
   return "OK";
 }
 
+export async function logoutUser(token: string) {
+  const session = await db.select().from(sessions).where(eq(sessions.token, token));
+
+  if (session.length === 0) {
+    throw new Error("Unauthorized");
+  }
+
+  await db.delete(sessions).where(eq(sessions.token, token));
+
+  return "OK";
+}
+
 export async function loginUser(email: string, password: string) {
   const result = await db.select().from(users).where(eq(users.email, email));
 


### PR DESCRIPTION
## Summary

- Tambah fungsi `logoutUser(token)` di `src/service/users-service.ts` — validasi token di tabel `sessions`, lalu hapus dengan `db.delete()`
- Tambah endpoint `POST /api/users/logout` di `src/route/users-route.ts` dengan autentikasi `Authorization: Bearer <token>`

## Test plan

- [x] Login untuk mendapatkan token
- [x] Logout dengan token valid → `{"data":"OK"}`
- [x] Verifikasi token tidak bisa dipakai setelah logout → `{"error":"Unauthorized"}`
- [x] Logout tanpa header Authorization → 401
- [x] Logout dengan token salah → 401
- [x] Logout dua kali dengan token sama → error 401 di percobaan kedua

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)