### PR TITLE
fix: validasi input dan sanitasi error pada registrasi user

### DIFF
--- a/src/route/users-route.ts
+++ b/src/route/users-route.ts
@@ -19,8 +19,21 @@ export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
       await createUser(name, email, password);
       return { data: "OK" };
     } catch (error) {
+      const message = (error as Error).message;
+      const safeErrors = [
+        "Nama tidak boleh kosong",
+        "Nama maksimal 255 karakter",
+        "Email tidak boleh kosong",
+        "Email maksimal 255 karakter",
+        "Password minimal 6 karakter",
+        "email sudah terdaftar",
+      ];
+
       set.status = 400;
-      return { error: (error as Error).message };
+      if (safeErrors.includes(message)) {
+        return { error: message };
+      }
+      return { error: "Terjadi kesalahan pada server" };
     }
   }
 )
@@ -33,8 +46,14 @@ export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
       const token = await loginUser(email, password);
       return { data: token };
     } catch (error) {
+      const message = (error as Error).message;
+      const safeErrors = ["Email atau Password Salah"];
+
       set.status = 400;
-      return { error: (error as Error).message };
+      if (safeErrors.includes(message)) {
+        return { error: message };
+      }
+      return { error: "Terjadi kesalahan pada server" };
     }
   })
   .post("/current", async ({ request, set }) => {

--- a/src/service/users-service.ts
+++ b/src/service/users-service.ts
@@ -30,6 +30,22 @@ export async function createUser(
   email: string,
   password: string
 ) {
+  if (!name || name.trim().length === 0) {
+    throw new Error("Nama tidak boleh kosong");
+  }
+  if (name.length > 255) {
+    throw new Error("Nama maksimal 255 karakter");
+  }
+  if (!email || email.trim().length === 0) {
+    throw new Error("Email tidak boleh kosong");
+  }
+  if (email.length > 255) {
+    throw new Error("Email maksimal 255 karakter");
+  }
+  if (!password || password.length < 6) {
+    throw new Error("Password minimal 6 karakter");
+  }
+
   const existing = await db
     .select()
     .from(users)


### PR DESCRIPTION
## Summary
- Tambah validasi panjang input (name, email, password) di service layer sebelum query ke database
- Sanitasi error message di route layer agar raw SQL error dan data sensitif (hashed password) tidak bocor ke client
- Terapkan pola whitelist untuk error message yang aman ditampilkan ke user

Closes #13

## Test plan
- [x] Nama 300 karakter → `{"error": "Nama maksimal 255 karakter"}`
- [x] Nama kosong → `{"error": "Nama tidak boleh kosong"}`
- [x] Email kosong → `{"error": "Email tidak boleh kosong"}`
- [x] Password < 6 karakter → `{"error": "Password minimal 6 karakter"}`
- [x] Registrasi normal → `{"data": "OK"}`
- [ ] Error database (misal MySQL mati) → `{"error": "Terjadi kesalahan pada server"}`, bukan raw SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)